### PR TITLE
Remove price failed_at data if success

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package can:
 
 Require this package: `composer require justbetter/laravel-magento-prices`
 
-Publish the config
+Publish the config:
 ```
 php artisan vendor:publish --provider="JustBetter\MagentoPrices\ServiceProvider" --tag="config"
 ```
@@ -37,6 +37,11 @@ php artisan vendor:publish --provider="JustBetter\MagentoPrices\ServiceProvider"
 Publish the activity log's migrations:
 ```
 php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-migrations"
+```
+
+Publish the batches table migration:
+```
+php artisan queue:batches-table
 ```
 
 Run migrations.

--- a/src/Actions/SyncPrices.php
+++ b/src/Actions/SyncPrices.php
@@ -9,7 +9,7 @@ use JustBetter\MagentoPrices\Models\MagentoPrice;
 
 class SyncPrices implements SyncsPrices
 {
-    public function sync(int $retrieveLimit = null, int $updateLimit = null): void
+    public function sync(?int $retrieveLimit = null, ?int $updateLimit = null): void
     {
         $this->resetDoubleStatus();
 

--- a/src/Contracts/SyncsPrices.php
+++ b/src/Contracts/SyncsPrices.php
@@ -4,5 +4,5 @@ namespace JustBetter\MagentoPrices\Contracts;
 
 interface SyncsPrices
 {
-    public function sync(int $retrieveLimit = null, int $updateLimit = null): void;
+    public function sync(?int $retrieveLimit = null, ?int $updateLimit = null): void;
 }

--- a/src/Data/PriceData.php
+++ b/src/Data/PriceData.php
@@ -24,8 +24,8 @@ class PriceData implements Arrayable
     public function __construct(
         string $sku,
         Collection $basePrices,
-        Collection $tierPrices = null,
-        Collection $specialPrices = null
+        ?Collection $tierPrices = null,
+        ?Collection $specialPrices = null
     ) {
         $this->sku = $sku;
         $this->basePrices = $basePrices;

--- a/src/Data/SpecialPriceData.php
+++ b/src/Data/SpecialPriceData.php
@@ -17,7 +17,7 @@ class SpecialPriceData implements Arrayable
 
     public Carbon $to;
 
-    public function __construct(Money $price, int $storeId = 0, Carbon $from = null, Carbon $to = null)
+    public function __construct(Money $price, int $storeId = 0, ?Carbon $from = null, ?Carbon $to = null)
     {
         $this->price = $price;
         $this->storeId = $storeId;

--- a/src/Jobs/UpdateMagentoBasePricesJob.php
+++ b/src/Jobs/UpdateMagentoBasePricesJob.php
@@ -2,6 +2,7 @@
 
 namespace JustBetter\MagentoPrices\Jobs;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -15,6 +16,7 @@ use Throwable;
 
 class UpdateMagentoBasePricesJob implements ShouldBeUnique, ShouldQueue
 {
+    use Batchable;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;

--- a/src/Jobs/UpdatePriceJob.php
+++ b/src/Jobs/UpdatePriceJob.php
@@ -52,7 +52,7 @@ class UpdatePriceJob implements ShouldBeUnique, ShouldQueue
             $this->handleTierPrices($data),
             $this->handleSpecialPrices($data),
         ]))
-            ->name('update-price-jobs')
+            ->name("Magento price update $this->sku")
             ->onQueue(config('magento-prices.queue'))
             ->then(function () use ($model): void {
                 $model->update([

--- a/tests/Feature/UpdatePricesJobTest.php
+++ b/tests/Feature/UpdatePricesJobTest.php
@@ -2,6 +2,7 @@
 
 namespace JustBetter\MagentoPrices\Tests\Feature;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
 use JustBetter\MagentoPrices\Commands\RetrievePricesCommand;
 use JustBetter\MagentoPrices\Commands\UpdatePriceCommand;
@@ -30,6 +31,14 @@ class UpdatePricesJobTest extends TestCase
 
         $this->artisan(UpdatePriceCommand::class, ['sku' => '123']);
 
-        Bus::assertDispatched(UpdateMagentoBasePricesJob::class);
+        Bus::assertBatched(function (PendingBatch $batch) {
+            foreach ($batch->jobs as $job) {
+                if ($job instanceof UpdateMagentoBasePricesJob) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
     }
 }

--- a/tests/Helpers/MoneyHelperTest.php
+++ b/tests/Helpers/MoneyHelperTest.php
@@ -9,7 +9,7 @@ use JustBetter\MagentoPrices\Tests\TestCase;
 class MoneyHelperTest extends TestCase
 {
     /** @dataProvider provider */
-    public function test_it_creates_money(float $amount, string $method, float $expectedAmount = null): void
+    public function test_it_creates_money(float $amount, string $method, ?float $expectedAmount = null): void
     {
         config()->set('laravel-magento-prices.currency', 'EUR');
         config()->set('laravel-magento-prices.precision', 4);


### PR DESCRIPTION
This PR resets the `failed_count` and `failed_at` to `NULL` if the prices have been updated with success.