### PR TITLE
Use PUT for sync action, same as async

### DIFF
--- a/src/Actions/Update/Sync/UpdateTierPrice.php
+++ b/src/Actions/Update/Sync/UpdateTierPrice.php
@@ -28,7 +28,7 @@ class UpdateTierPrice implements UpdatesTierPrice
         }
 
         $response = $this->magento
-            ->post('products/tier-prices', ['prices' => $payload])
+            ->put('products/tier-prices', ['prices' => $payload])
             ->onError(function (Response $response) use ($price, $payload): void {
                 activity()
                     ->on($price)


### PR DESCRIPTION
The async update uses PUT (replace) but the sync action used POST which doesn't replace existing tier prices.